### PR TITLE
Flexibility for platforms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     - setup_remote_docker
     - run:
         name: Build image
-        command: docker build --build-arg arch="amd64" -t "${IMAGE_NAME}:ci" .
+        command: docker build --build-arg ARCHITECTURE="amd64" -t "${IMAGE_NAME}:ci" .
     - run:
         name: Scan image
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     - setup_remote_docker
     - run:
         name: Build image
-        command: docker build -t "${IMAGE_NAME}:ci" .
+        command: docker build --build-arg arch="amd64" -t "${IMAGE_NAME}:ci" .
     - run:
         name: Scan image
         command: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build the Docker image
-        run: docker build -t elabftw/elabimg:ci .
+        run: docker build --build-arg arch="amd64" -t elabftw/elabimg:ci .
       - uses: anchore/scan-action@v2
         with:
           image: "elabftw/elabimg:ci"

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build the Docker image
-        run: docker build --build-arg arch="amd64" -t elabftw/elabimg:ci .
+        run: docker build --build-arg ARCHITECTURE="amd64" -t elabftw/elabimg:ci .
       - uses: anchore/scan-action@v2
         with:
           image: "elabftw/elabimg:ci"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ENV ELABIMG_VERSION 2.4.0
 
 ENV S6_OVERLAY_VERSION 2.2.0.1
 
+ENV ARCHITECTURE amd64
+
 LABEL org.label-schema.name="elabftw" \
     org.label-schema.description="Run nginx and php-fpm to serve elabftw" \
     org.label-schema.url="https://www.elabftw.net" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ ENV ELABIMG_VERSION 2.4.0
 
 ENV S6_OVERLAY_VERSION 2.2.0.1
 
-# the architecture to build for, necessary for S6
-ENV ARCHITECTURE=$arch
-
 LABEL org.label-schema.name="elabftw" \
     org.label-schema.description="Run nginx and php-fpm to serve elabftw" \
     org.label-schema.url="https://www.elabftw.net" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ ENV ELABIMG_VERSION 2.4.0
 
 ENV S6_OVERLAY_VERSION 2.2.0.1
 
-ENV ARCHITECTURE amd64
+# after https://stackoverflow.com/questions/45277186/is-it-possible-to-add-environment-variables-in-automated-builds-in-docker-hub
+ARG ARCHITECTURE
+ENV ARCHITECTURE $ARCHITECTURE
 
 LABEL org.label-schema.name="elabftw" \
     org.label-schema.description="Run nginx and php-fpm to serve elabftw" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ENV ELABIMG_VERSION 2.4.0
 
 ENV S6_OVERLAY_VERSION 2.2.0.1
 
+# the architecture to build for, necessary for S6
+ENV ARCHITECTURE=$arch
+
 LABEL org.label-schema.name="elabftw" \
     org.label-schema.description="Run nginx and php-fpm to serve elabftw" \
     org.label-schema.url="https://www.elabftw.net" \
@@ -18,8 +21,8 @@ LABEL org.label-schema.name="elabftw" \
     org.label-schema.schema-version="1.0"
 
 # install s6-overlay, our init system
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz /tmp/
-RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C /
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${ARCHITECTURE}.tar.gz /tmp/
+RUN tar xzf /tmp/s6-overlay-${ARCHITECTURE}.tar.gz -C /
 
 # install nginx and php-fpm
 # php8-gd is required by mpdf for transparent png

--- a/hooks/build
+++ b/hooks/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --build-arg ARCHITECTURE="amd64" -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+docker build --build-arg ARCHITECTURE=$ARCH -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,1 @@
+docker build --build-arg arch="amd64" -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,1 +1,2 @@
+#!/bin/bash
 docker build --build-arg arch="amd64" -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker build --build-arg ARCHITECTURE=$ARCH -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+
+docker build --build-arg ARCHITECTURE=$ARCHITECTURE -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --build-arg arch="amd64" -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+docker build --build-arg ARCHITECTURE="amd64" -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,3 +1,8 @@
 #!/bin/bash
-
-docker build --build-arg ARCHITECTURE=$ARCHITECTURE -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+if [ $ARCHITECTURE = 'arm' ]; then
+    docker buildx build --platform linux/arm/v7 --build-arg ARCHITECTURE=$ARCHITECTURE -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+elif [ $ARCHITECTURE = 'aarch64' ]; then
+    docker buildx build --platform linux/arm64 --build-arg ARCHITECTURE=$ARCHITECTURE -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+else
+    docker build --build-arg ARCHITECTURE="amd64" -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+fi


### PR DESCRIPTION
> IMPORTANT: Base your PR off the 'hypernext' branch.

Instead of creating another docker file I thought maybe this would be an ok solution to add flexibility for building for other platforms. I think this should work if I read the docker documentation correctly but have not tested. Then I think could create my own Github action in a separate repo which builds for ARM using this repo directly and pushes to my docker hub account.