### PR TITLE
Dockerfile fix for buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,8 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/
 # nginx will run on port 443
 EXPOSE 443
 
+# Remove the contents of /etc/nginx/ due to copy conflicts for buildx see https://github.com/docker/buildx/issues/150
+RUN rm -rf /etc/nginx/*
 # copy configuration and run script
 COPY ./src/nginx/ /etc/nginx/
 COPY ./src/run.sh /run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/
 EXPOSE 443
 
 # Remove the contents of /etc/nginx/ due to copy conflicts for buildx see https://github.com/docker/buildx/issues/150
-RUN rm -rf /etc/nginx/*
+RUN rm -r /etc/nginx
 # copy configuration and run script
 COPY ./src/nginx/ /etc/nginx/
 COPY ./src/run.sh /run.sh


### PR DESCRIPTION
I discovered that docker buildx behaves a bit differently than docker build. It turns out that since you updated/added some files in `./src/nginx/`, the `COPY` command on line 97 gave an error since there is already a similar named default file or folder in the destination `/etc/nginx`. For reference, the error I was getting:

```
Dockerfile:98
--------------------
  96 |     
  97 |     # copy configuration and run script
  98 | >>> COPY ./src/nginx/ /etc/nginx/
  99 |     COPY ./src/run.sh /run.sh
 100 |     COPY ./src/services /etc/services.d
--------------------
error: failed to solve: rpc error: code = Unknown desc = cannot copy to non-directory: /tmp/buildkit-mount329749225/etc/nginx/conf.d
Error: buildx call failed with: error: failed to solve: rpc error: code = Unknown desc = cannot copy to non-directory: /tmp/buildkit-mount329749225/etc/nginx/conf.d
```

Apparently docker build will interpret `COPY` as a hard overwrite, whereas buildx will not allow you to do this.

Removing the contents of `/etc/nginx` fixed the issue. The question is whether there are default contents in this folder that need to be conserved.