### PR TITLE
Changing MySQL port.

### DIFF
--- a/src/docker-compose.yml-EXAMPLE
+++ b/src/docker-compose.yml-EXAMPLE
@@ -255,6 +255,8 @@ services:
         - MYSQL_PASSWORD=secr3t
         # need to change, this is your timezone, see PHP_TIMEZONE from the elabftw container
         - TZ=Europe/Paris
+        # Update this if you want to run the server on a different port than 3306. Also update the expose directive below.
+        # - MYSQL_TCP_PORT=3306
 
     volumes:
         # this is where you will keep the database persistently
@@ -262,6 +264,9 @@ services:
         # - D:\Users\Nico\elab-data\mysql:/var/lib/mysql
         # host:container
         - /var/elabftw/mysql:/var/lib/mysql
+     # The official mysql docker image will by default expose ports 3306 and 33060.
+     # See definitions under https://hub.docker.com/_/mysql , and mysql.com documentation.
+     # Ports below appear to be exposed _in addition to_ this.
     expose:
       - '3306'
     networks:

--- a/src/docker-compose.yml-EXAMPLE
+++ b/src/docker-compose.yml-EXAMPLE
@@ -255,7 +255,7 @@ services:
         - MYSQL_PASSWORD=secr3t
         # need to change, this is your timezone, see PHP_TIMEZONE from the elabftw container
         - TZ=Europe/Paris
-        # Update this if you want to run the server on a different port than 3306. Also update the expose directive below.
+        # Update this if you want to run the server on a different port than 3306.
         # - MYSQL_TCP_PORT=3306
 
     volumes:
@@ -264,9 +264,8 @@ services:
         # - D:\Users\Nico\elab-data\mysql:/var/lib/mysql
         # host:container
         - /var/elabftw/mysql:/var/lib/mysql
-     # The official mysql docker image will by default expose ports 3306 and 33060.
-     # See definitions under https://hub.docker.com/_/mysql , and mysql.com documentation.
-     # Ports below appear to be exposed _in addition to_ this.
+     # The mysql container exposes 3306/33060. Though it does not make an operational difference,
+     # make sure to document your usage here.
     expose:
       - '3306'
     networks:


### PR DESCRIPTION
If someone wants to run MySQL on a different port, they 
- need to tell eLabFTW this,
- need to tell MySQL this,
- need to tell Docker to expose the right port.

The original docker-compose file suggested (i) and (iii) but left (ii) as the responsibility of the user. This update adds a note suggesting how to do this.

Also, I noted that it _seems_ docker will still expose the old ports defined in the image (3306, 33060), regardless of the docker-compose file. I'm not too bothered by this in this particular case, but it was an interesting surprise in terms of understanding how docker-compose works as _enabling_ rather than _defining_ or _constricting_.

I've kept the _seemingly_ superfluous expose directive, since it's nice and consistent in the file (and it might prove useful if it is eg re[kompose](https://kubernetes.io/docs/tasks/configure-pod-container/translate-compose-kubernetes/)d sometime later).