### PR TITLE
Allow for automatic database migrations

### DIFF
--- a/src/init/prepare.sh
+++ b/src/init/prepare.sh
@@ -281,7 +281,7 @@ migrations() {
 elabimg: info: intializing database structure
 EOT
         fi
-        bin/install start | tee $initPath
+        bin/install start
     fi
     if [ "${silent_init}" = false ]; then
         cat >&2 <<EOT

--- a/src/init/prepare.sh
+++ b/src/init/prepare.sh
@@ -278,10 +278,12 @@ EOT
 migrations() {
     mkdir -p $migration_data_dir
     initPath="$migration_data_dir/.dbinit"
-    if [ ! -f $initPath ] && [ ! $skip_db_init ]; then
-        cat >&2 <<EOT
+    if [ ! -f $initPath ] && [ "$skip_db_init" = false ]; then
+        if [ "${silent_init}" = false ]; then
+            cat >&2 <<EOT
 INFO: Init database structure
 EOT
+        fi
         bin/install start | tee $initPath
     fi
     bin/console db:update
@@ -297,7 +299,7 @@ phpConf
 elabftwConf
 writeConfigFile
 
-if ($auto_migration); then
+if [ "$auto_migration" = true ]; then
     migrations
 fi
 

--- a/src/init/prepare.sh
+++ b/src/init/prepare.sh
@@ -52,9 +52,8 @@ getEnv() {
     # allow limiting log pollution on startup
     silent_init=${SILENT_INIT:-false}
     dev_mode=${DEV_MODE:-false}
-    auto_migration=${AUTO_MIGRATION:-false}
-    skip_db_init=${SKIP_DB_INIT:-true}
-    migration_data_dir=${MIGRATION_DATA_DIR:-/elabftw/migration_state}
+    auto_db_update=${AUTO_DB_UPDATE:-false}
+    auto_db_init=${AUTO_DB_INIT:-false}
     aws_ak=${ELAB_AWS_ACCESS_KEY:-}
     unset ELAB_AWS_ACCESS_KEY
     aws_sk=${ELAB_AWS_SECRET_KEY:-}
@@ -276,15 +275,18 @@ EOT
 }
 
 migrations() {
-    mkdir -p $migration_data_dir
-    initPath="$migration_data_dir/.dbinit"
-    if [ ! -f $initPath ] && [ "$skip_db_init" = false ]; then
+    if [ "$auto_db_init" = true ]; then
         if [ "${silent_init}" = false ]; then
             cat >&2 <<EOT
-INFO: Init database structure
+elabimg: info: intializing database structure
 EOT
         fi
         bin/install start | tee $initPath
+    fi
+    if [ "${silent_init}" = false ]; then
+        cat >&2 <<EOT
+elabimg: info: updating database structure
+EOT
     fi
     bin/console db:update
 }
@@ -299,7 +301,7 @@ phpConf
 elabftwConf
 writeConfigFile
 
-if [ "$auto_migration" = true ]; then
+if [ "$auto_db_update" = true ]; then
     migrations
 fi
 


### PR DESCRIPTION
### Content
This pull request introduces the options to automatically init the database on first startup and to execute db migrations on every start of the docker image. The docker images consumes the following extra environment variables:

- AUTO_DB_UPDATE (default: false): Controls if changes to the database should be made by the startup script.
- AUTO_DB_INIT (default: false): Should the install command be run automatically

### Why did I introduce this change?
Without this change it is necessary to manually execute docker run commands after every deployment. This is okay if one has a local docker installation and uses elabctl but for cloud installations this can be cumbersome. There are environments where shell access is not permitted/possible or one prefers to execute all changes using an automation pipeline without extra post install commands. Due to the fact that automatic migrations can also have a negative side effect this feature is purely optional.