### PR TITLE
Fixes #30 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,7 +188,9 @@ RUN ln -s /usr/bin/php81 /usr/bin/php
 ARG S6_OVERLAY_VERSION=3.1.2.0
 ENV S6_OVERLAY_VERSION $S6_OVERLAY_VERSION
 
-ARG TARGETPLATFORM=linux/amd64
+# using an explicit default argument for TARGETPLATFORM will override the buildx implicit value
+ARG TARGETPLATFORM
+ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x86_64; elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=arm; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=aarch64; else ARCHITECTURE=amd64; fi \
     && curl -sS -L -O --output-dir /tmp/ --create-dirs "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${ARCHITECTURE}.tar.xz" \
     && curl -sS -L -O --output-dir /tmp/ --create-dirs "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \


### PR DESCRIPTION
Using an explicit default argument for TARGETPLATFORM will override the buildx implicit value and this breaks the buildx process for arm64 platforms.

Tested the buildx process successfully with github action (see hhttps://github.com/nilssta/elabimg/actions/runs/3969379939/jobs/6803795494#step:8:4100), the action logs show the now correctly adopted targetplatform:

```
#104 [linux/arm64 stage-2  8/39] RUN if [ "linux/arm64" = "linux/amd64" ]; then ARCHITECTURE=x86_64; elif [ "linux/arm64" = "linux/arm/v7" ]; then ARCHITECTURE=arm; elif [ "linux/arm64" = "linux/arm64" ]; then ARCHITECTURE=aarch64; else ARCHITECTURE=amd64; fi     && curl -sS -L -O --output-dir /tmp/ --create-dirs "[https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-${ARCHITECTURE}.tar.xz](https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-$%7BARCHITECTURE%7D.tar.xz)"     && curl -sS -L -O --output-dir /tmp/ --create-dirs "https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-noarch.tar.xz"     && tar xpJf "/tmp/s6-overlay-${ARCHITECTURE}.tar.xz" -C /     && tar xpJf "/tmp/s6-overlay-noarch.tar.xz" -C /
#104 DONE 2.2s
```

Also verified that docker images are working on arm64 (using Ubuntu 22.04.1 LTS) and amd64 (Ubuntu 22.10).

