### PR TITLE
Enable external auth when using headers with underscores

### DIFF
--- a/src/nginx/common.conf
+++ b/src/nginx/common.conf
@@ -27,6 +27,9 @@ error_page 533 /error-pages/533.html;
 #%REAL_IP_CONF%
 #real_ip_header X-Forwarded-For;
 
+# enable external auth when using headers with underscores
+underscores_in_headers on;
+
 # whitelist allowed methods
 if ($request_method !~ ^(GET|HEAD|POST|DELETE|OPTIONS|PATCH)$) {
     return 405;


### PR DESCRIPTION
Enable external auth when using headers with underscores 
e.g. when using https://github.com/OpenIDC/mod_auth_openidc

Closes: https://github.com/elabftw/elabftw/issues/4059