### PR TITLE
fix: correct auto db initialization step in prepare.sh script

### DIFF
--- a/src/init/prepare.sh
+++ b/src/init/prepare.sh
@@ -383,7 +383,7 @@ startupMessage() {
 dbInit() {
     if ($auto_db_init); then
         say "elabimg: info: initializing database structure"
-        /elabftw/bin/install start
+        /elabftw/bin/init db:install
     fi
 }
 


### PR DESCRIPTION
AUTO_DB_INIT variable is not working as expected with the docker environment. The prepare.sh script actually prints out an error because the `/usr/sbin/install` file is not existing, it should be targeting the `/usr/sbin/init` file instead.

Closes this issue : #34 