### PR TITLE
feat: nginx: cache responses from app/download.php results

### DIFF
--- a/src/nginx/common.conf
+++ b/src/nginx/common.conf
@@ -78,6 +78,18 @@ location = /nginx-status {
 # deny access to hidden files/folders
 location ~ /\.  { access_log off; log_not_found off; deny all; }
 
+# for user uploaded files, use a long cache value, as uploads are not modified anyway: an URL points always to the same exact file
+location ^~ /app/download.php {
+    more_set_headers Cache-Control "public, max-age=31536000";
+    include         /etc/nginx/fastcgi.conf;
+    fastcgi_index  index.php;
+    log_not_found off;
+
+    if (-f $request_filename) {
+        fastcgi_pass   unix:/run/php-fpm.sock;
+    }
+}
+
 # assets configuration
 location ~* \.(js|css|png|jpg|jpeg|gif|ico|map|ttf|txt|woff|woff2|svg|webmanifest)$ {
     access_log off;

--- a/src/nginx/common.conf
+++ b/src/nginx/common.conf
@@ -80,7 +80,7 @@ location ~ /\.  { access_log off; log_not_found off; deny all; }
 
 # for user uploaded files, use a long cache value, as uploads are not modified anyway: an URL points always to the same exact file
 location ^~ /app/download.php {
-    more_set_headers Cache-Control "public, max-age=31536000";
+    more_set_headers "Cache-Control: public, max-age=31536000";
     include         /etc/nginx/fastcgi.conf;
     fastcgi_index  index.php;
     log_not_found off;


### PR DESCRIPTION
This configuration change prevents the browser from systematically downloading thumbnails of uploaded files. Because "uploads" URLs are always pointing to the same exact file, we can cache the response.
