### PR TITLE
remove opencloning prefix in proxy

### DIFF
--- a/src/nginx/opencloning.conf
+++ b/src/nginx/opencloning.conf
@@ -1,4 +1,7 @@
 location ^~ /opencloning {
+    # Remove the opencloning prefix from the URL before proxying
+    # Handle both trailing and non-trailing slash cases
+    rewrite ^/opencloning/?(.*) /$1 break;
     # this URL is set by entrypoint script
     proxy_pass %OPENCLONING_URL%;
 }


### PR DESCRIPTION
remove opencloning prefix in proxy


Somehow the same `ROOT_PATH` uvicorn settings stopped behaving the same way. I think because now I run the server as a module. Related to this known painful inconsistent behaviour - https://github.com/fastapi/fastapi/discussions/9018