### PR TITLE
Update docker example opencloning url

### DIFF
--- a/src/docker-compose.yml-EXAMPLE
+++ b/src/docker-compose.yml-EXAMPLE
@@ -305,7 +305,7 @@ services:
         #- FINGERPRINTER_URL=http://chem-plugin:8000/
         # This is for the integration of the DNA Cloning tool
         #- USE_OPENCLONING=false
-        #- OPENCLONING_URL=http://opencloning-plugin/
+        #- OPENCLONING_URL=http://opencloning-plugin:8000/
 
         #######
         # DEV #


### PR DESCRIPTION
Fix #50 
URL for exposing opencloning is missing the port number (8000)