### PR TITLE
bug/minor: opencloning: fix exports/downloads

### DIFF
--- a/src/nginx/common.conf
+++ b/src/nginx/common.conf
@@ -137,10 +137,19 @@ location ~ ^/(%PHP_FILES_NGINX_ALLOWLIST%)$|^/$ {
     }
 }
 
-# this page won't allow for restrictive csp, therefore we include 'unsafe-eval' in script-src. see https://github.com/epam/ketcher/issues/6603
+# allow 'unsafe-eval': the chemical structure editor page won't allow for restrictive csp, therefore
+# we include 'unsafe-eval' in script-src. see https://github.com/epam/ketcher/issues/6603
 location = /chem-editor.php {
     more_clear_headers "Content-Security-Policy";
     more_set_headers "Content-Security-Policy: default-src 'self' data:; script-src 'self' 'unsafe-eval'; connect-src 'self' blob: https://get.elabftw.net https://pubchem.ncbi.nlm.nih.gov; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'self'; base-uri 'none'; frame-ancestors 'self'";
+    include        /etc/nginx/fastcgi.conf;
+    fastcgi_pass   unix:/run/php-fpm.sock;
+}
+
+# allow blob: in frame-src for OpenCloning (syc.php). see https://github.com/elabftw/elabimg/issues/55
+location = /syc.php {
+    more_clear_headers "Content-Security-Policy";
+    more_set_headers "Content-Security-Policy: default-src 'self' data:; script-src 'self' %UNSAFE-EVAL4DEV%; connect-src 'self' blob: https://get.elabftw.net https://pubchem.ncbi.nlm.nih.gov; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'self'; base-uri 'none'; frame-src 'self' blob:; frame-ancestors 'self'";
     include        /etc/nginx/fastcgi.conf;
     fastcgi_pass   unix:/run/php-fpm.sock;
 }


### PR DESCRIPTION
- Fixes #55

Exporting a sequence on opencloning results in an error message : 
```
Content-Security-Policy: The page’s settings blocked the loading of a resource (frame-src) at blob:https://demo.elabftw.net/a14bbee8-fca8-4d82-84ac-e46c19f9f868 because it violates the following directive: “default-src 'self' data:”
```

This PR provides specific `syc.php` CSP allowing loading content into iframes from blob:URL.