### PR TITLE
Add support for docker secrets.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -269,6 +269,9 @@ WORKDIR /elabftw
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:2.9.4 /usr/bin/composer /usr/bin/composer
 
+#### ADD PATCH
+COPY ./Env-patch.php /elabftw/src/Elabftw/Env.php
+
 # this allows to skip the (long) build in dev mode where /elabftw will be bind-mounted anyway
 # pass it to build command with --build-arg BUILD_ALL=0
 ARG BUILD_ALL=1
@@ -314,6 +317,7 @@ RUN echo "entrypoint" > /etc/s6-overlay/s6-rc.d/nginx/dependencies
 RUN echo "entrypoint" > /etc/s6-overlay/s6-rc.d/php/dependencies
 
 COPY ./src/entrypoint/docker-entrypoint.sh /usr/sbin/docker-entrypoint.sh
+
 # these values are not in env and cannot be accessed by script so modify them here
 RUN sed -i -e "s/%ELABIMG_VERSION%/$ELABIMG_VERSION/" \
     -e "s/%ELABFTW_VERSION%/$ELABFTW_VERSION/" \
@@ -321,7 +325,9 @@ RUN sed -i -e "s/%ELABIMG_VERSION%/$ELABIMG_VERSION/" \
 
 # add defaults - may be overridden with compose
 ENV DB_PASSWORD_FILE=/run/secrets/elab_db_password
-ENV SECRET_KEY_FILE=/run/sercets/elab_secret_key
+ENV SECRET_KEY_FILE=/run/secrets/elab_secret_key
+ENV AWS_ACCESS_KEY_FILE=/run/secrets/aws_access_key
+ENV AWS_SECRET_KEY_FILE=/run/secrets/aws_secret_key
 # END DOCKER-ENTRYPOINT.SH
 
 # INVOKER

--- a/Dockerfile
+++ b/Dockerfile
@@ -318,6 +318,10 @@ COPY ./src/entrypoint/docker-entrypoint.sh /usr/sbin/docker-entrypoint.sh
 RUN sed -i -e "s/%ELABIMG_VERSION%/$ELABIMG_VERSION/" \
     -e "s/%ELABFTW_VERSION%/$ELABFTW_VERSION/" \
     -e "s/%S6_OVERLAY_VERSION%/$S6_OVERLAY_VERSION/" /usr/sbin/docker-entrypoint.sh
+
+# add defaults - may be overridden with compose
+ENV DB_PASSWORD_FILE=/run/secrets/elab_db_password
+ENV SECRET_KEY_FILE=/run/sercets/elab_secret_key
 # END DOCKER-ENTRYPOINT.SH
 
 # INVOKER

--- a/Dockerfile
+++ b/Dockerfile
@@ -326,8 +326,8 @@ RUN sed -i -e "s/%ELABIMG_VERSION%/$ELABIMG_VERSION/" \
 # add defaults - may be overridden with compose
 ENV DB_PASSWORD_FILE=/run/secrets/elab_db_password
 ENV SECRET_KEY_FILE=/run/secrets/elab_secret_key
-ENV AWS_ACCESS_KEY_FILE=/run/secrets/aws_access_key
-ENV AWS_SECRET_KEY_FILE=/run/secrets/aws_secret_key
+ENV ELAB_AWS_ACCESS_KEY_FILE=/run/secrets/aws_access_key
+ENV ELAB_AWS_SECRET_KEY_FILE=/run/secrets/aws_secret_key
 # END DOCKER-ENTRYPOINT.SH
 
 # INVOKER

--- a/src/entrypoint/docker-entrypoint.sh
+++ b/src/entrypoint/docker-entrypoint.sh
@@ -18,6 +18,7 @@ getEnv() {
     db_user=${DB_USER:-elabftw}
     # Note: no default value here
     db_password=${DB_PASSWORD:-}
+    db_password_file=${DB_PASSWORD_FILE:-}
     db_cert_path=${DB_CERT_PATH:-}
     site_url=${SITE_URL:-https://localhost}
     # remove trailing slash for site_url
@@ -26,6 +27,7 @@ getEnv() {
     disable_https=${DISABLE_HTTPS:-false}
     enable_letsencrypt=${ENABLE_LETSENCRYPT:-false}
     secret_key=${SECRET_KEY:-}
+    secret_key_file=${SECRET_KEY_FILE:-}
     max_php_memory=${MAX_PHP_MEMORY:-2G}
     max_upload_size=${MAX_UPLOAD_SIZE:-100M}
     max_upload_time=${MAX_UPLOAD_TIME:-900000}
@@ -42,6 +44,7 @@ getEnv() {
     redis_port=${REDIS_PORT:-6379}
     redis_username=${REDIS_USERNAME:-}
     redis_password=${REDIS_PASSWORD:-}
+    redis_password_file=${REDIS_PASSWORD_FILE:-}
     enable_ipv6=${ENABLE_IPV6:-false}
     elabftw_user=${ELABFTW_USER:-nginx}
     elabftw_group=${ELABFTW_GROUP:-nginx}
@@ -56,7 +59,9 @@ getEnv() {
     auto_db_init=${AUTO_DB_INIT:-false}
     auto_db_update=${AUTO_DB_UPDATE:-false}
     aws_ak=${ELAB_AWS_ACCESS_KEY:-}
+    aws_ak_file=${ELAB_AWS_ACCESS_KEY_FILE:-}
     aws_sk=${ELAB_AWS_SECRET_KEY:-}
+    aws_sk_file=${ELAB_AWS_SECRET_KEY_FILE:-}
     ldap_tls_reqcert=${LDAP_TLS_REQCERT:-false}
     allow_origin=${ALLOW_ORIGIN:-}
     allow_methods=${ALLOW_METHODS:-}
@@ -285,6 +290,9 @@ getRedisUri() {
     if [ -n "$redis_username" ]; then
         username="\?auth[user]=${redis_username}"
     fi
+    if [[ -n $redis_password_file && -r $redis_password_file ]]; then
+        redis_password=$(cat "${redis_password_file}")
+    fi
     if [ -n "$redis_password" ]; then
         if [ -z "$redis_username" ]; then
             query_link="\?"
@@ -329,7 +337,7 @@ phpConf() {
     # production open_basedir conf value
     # /etc/ssl/cert.pem is for openssl and timestamp related functions
     # for /run/s6-rc... see elabftw/elabftw#5249
-    open_basedir="/.dockerenv:/elabftw/:/tmp/:/usr/bin/unzip:/etc/ssl/cert.pem:/run/s6-rc/servicedirs/s6rc-oneshot-runner"
+    open_basedir="/.dockerenv:/elabftw/:/tmp/:/usr/bin/unzip:/etc/ssl/cert.pem:/run/s6-rc/servicedirs/s6rc-oneshot-runner:/run/secrets"
     # DEV MODE
     if ($dev_mode); then
         # we don't want to use opcache as we want our changes to be immediately visible
@@ -371,6 +379,9 @@ populatePhpEnv() {
     sed -i -e "s/%DB_PORT%/${db_port}/" /etc/php84/php-fpm.d/elabpool.conf
     sed -i -e "s/%DB_NAME%/${db_name}/" /etc/php84/php-fpm.d/elabpool.conf
     sed -i -e "s/%DB_USER%/${db_user}/" /etc/php84/php-fpm.d/elabpool.conf
+    if [[ -n $db_password_file && -r $db_password_file ]]; then 
+        db_password=$(cat "${db_password_file}")
+    fi
     sed -i -e "s/%DB_PASSWORD%/${db_password}/" /etc/php84/php-fpm.d/elabpool.conf
     # don't add empty stuff
     if [ -n "$db_cert_path" ]; then
@@ -380,17 +391,28 @@ populatePhpEnv() {
         # remove this if not in use
         sed -i -e "/%DB_CERT_PATH%/d" /etc/php84/php-fpm.d/elabpool.conf
     fi
+    if [[ -n $secret_key_file && -r $secret_key_file ]]; then
+        secret_key=$(cat "${secret_key_file}")
+    fi
     sed -i -e "s/%SECRET_KEY%/${secret_key}/" /etc/php84/php-fpm.d/elabpool.conf
     sed -i -e "s/%MAX_UPLOAD_SIZE%/${max_upload_size}/" /etc/php84/php-fpm.d/elabpool.conf
     sed -i -e "s/%MAX_UPLOAD_TIME%/${max_upload_time}/" /etc/php84/php-fpm.d/elabpool.conf
     # use # as separator instead of slash
     sed -i -e "s#%SITE_URL%#${site_url}#" /etc/php84/php-fpm.d/elabpool.conf
-    # assume that if ak is set, then sk is too
-    if [ -n "$aws_ak" ]; then
+    if [[ -n $aws_ak || -n $aws_ak_file ]]; then
+        if [[ -n aws_ak_file && -r $aws_ak_file ]]; then 
+            aws_ak=$(cat "${aws_ak_file}")
+        fi
         sed -i -e "s|%ELAB_AWS_ACCESS_KEY%|${aws_ak}|" /etc/php84/php-fpm.d/elabpool.conf
-        sed -i -e "s|%ELAB_AWS_SECRET_KEY%|${aws_sk}|" /etc/php84/php-fpm.d/elabpool.conf
     else
         sed -i -e "/%ELAB_AWS_ACCESS_KEY%/d" /etc/php84/php-fpm.d/elabpool.conf
+    fi 
+    if [[ -n $aws_sk || -n $aws_sk_file ]]; then
+        if [[ -n $aws_sk_file && -r $aws_sk_file ]]; then
+            aws_sk=$(cat "${aws_sk_file}")
+        fi
+        sed -i -e "s|%ELAB_AWS_SECRET_KEY%|${aws_sk}|" /etc/php84/php-fpm.d/elabpool.conf
+    else
         sed -i -e "/%ELAB_AWS_SECRET_KEY%/d" /etc/php84/php-fpm.d/elabpool.conf
     fi
 }

--- a/src/entrypoint/docker-entrypoint.sh
+++ b/src/entrypoint/docker-entrypoint.sh
@@ -396,13 +396,15 @@ populatePhpEnv() {
 
 populateSecrets() {
     if [[ ! -d /run/secrets ]]; then
-        mkdir /run/secrets
+        install -d -m 0750 /run/secrets
     fi
 
     if [[ -n $aws_ak || -n $aws_ak_file ]]; then
         if [[ ! -r $aws_ak_file ]]; then 
             aws_ak_file=/run/secrets/elab_aws_access_key
             printf "%s" "$aws_ak" > "$aws_ak_file"
+            chown "${elabftw_user}":"${elabftw_group}" "$aws_ak_file"
+            chmod 400 "$aws_ak_file"
         fi
         sed -i -e "s|%ELAB_AWS_ACCESS_KEY%|${aws_ak_file}|" /etc/php84/php-fpm.d/elabpool.conf
     else
@@ -411,8 +413,10 @@ populateSecrets() {
     
     if [[ -n $aws_sk || -n $aws_sk_file ]]; then
         if [[ ! -r $aws_sk_file ]]; then 
-            $aws_sk_file=/run/secrets/elab_aws_secret_key
+            aws_sk_file=/run/secrets/elab_aws_secret_key
             printf "%s" "$aws_sk" > "$aws_sk_file"
+            chown "${elabftw_user}":"${elabftw_group}" "$aws_sk_file"
+            chmod 400 "$aws_sk_file"
         fi
         sed -i -e "s|%ELAB_AWS_SECRET_KEY%|${aws_sk_file}|" /etc/php84/php-fpm.d/elabpool.conf
     else
@@ -422,12 +426,16 @@ populateSecrets() {
     if [[ ! -r $secret_key_file ]]; then
         secret_key_file=/run/secrets/elab_secret_key
         printf "%s" "$secret_key" > "$secret_key_file"
+        chown "${elabftw_user}":"${elabftw_group}" "$secret_key_file"
+        chmod 400 "$secret_key_file"
     fi
     sed -i -e "s|%SECRET_KEY%|${secret_key_file}|" /etc/php84/php-fpm.d/elabpool.conf
 
     if [[ ! -r $db_password_file ]]; then
         db_password_file="/run/secrets/elab_db_password"
         printf "%s" "$db_password" > "$db_password_file"
+        chown "${elabftw_user}":"${elabftw_group}" "$db_password_file"
+        chmod 400 "$db_password_file"
     fi
     sed -i -e "s|%DB_PASSWORD%|${db_password_file}|" /etc/php84/php-fpm.d/elabpool.conf
 }

--- a/src/entrypoint/docker-entrypoint.sh
+++ b/src/entrypoint/docker-entrypoint.sh
@@ -401,7 +401,6 @@ populateSecrets() {
 
     if [[ -n $aws_ak || -n $aws_ak_file ]]; then
         if [[ ! -r $aws_ak_file ]]; then 
-            aws_ak_file=/run/secrets/elab_aws_access_key
             printf "%s" "$aws_ak" > "$aws_ak_file"
             chown "${elabftw_user}":"${elabftw_group}" "$aws_ak_file"
             chmod 400 "$aws_ak_file"
@@ -413,7 +412,6 @@ populateSecrets() {
     
     if [[ -n $aws_sk || -n $aws_sk_file ]]; then
         if [[ ! -r $aws_sk_file ]]; then 
-            aws_sk_file=/run/secrets/elab_aws_secret_key
             printf "%s" "$aws_sk" > "$aws_sk_file"
             chown "${elabftw_user}":"${elabftw_group}" "$aws_sk_file"
             chmod 400 "$aws_sk_file"
@@ -424,7 +422,6 @@ populateSecrets() {
     fi
     
     if [[ ! -r $secret_key_file ]]; then
-        secret_key_file=/run/secrets/elab_secret_key
         printf "%s" "$secret_key" > "$secret_key_file"
         chown "${elabftw_user}":"${elabftw_group}" "$secret_key_file"
         chmod 400 "$secret_key_file"
@@ -432,7 +429,6 @@ populateSecrets() {
     sed -i -e "s|%SECRET_KEY%|${secret_key_file}|" /etc/php84/php-fpm.d/elabpool.conf
 
     if [[ ! -r $db_password_file ]]; then
-        db_password_file="/run/secrets/elab_db_password"
         printf "%s" "$db_password" > "$db_password_file"
         chown "${elabftw_user}":"${elabftw_group}" "$db_password_file"
         chmod 400 "$db_password_file"

--- a/src/entrypoint/docker-entrypoint.sh
+++ b/src/entrypoint/docker-entrypoint.sh
@@ -374,15 +374,11 @@ ldapConf() {
 }
 
 populatePhpEnv() {
-
     sed -i -e "s/%DB_HOST%/${db_host}/" /etc/php84/php-fpm.d/elabpool.conf
     sed -i -e "s/%DB_PORT%/${db_port}/" /etc/php84/php-fpm.d/elabpool.conf
     sed -i -e "s/%DB_NAME%/${db_name}/" /etc/php84/php-fpm.d/elabpool.conf
     sed -i -e "s/%DB_USER%/${db_user}/" /etc/php84/php-fpm.d/elabpool.conf
-    if [[ -n $db_password_file && -r $db_password_file ]]; then 
-        db_password=$(cat "${db_password_file}")
-    fi
-    sed -i -e "s/%DB_PASSWORD%/${db_password}/" /etc/php84/php-fpm.d/elabpool.conf
+   
     # don't add empty stuff
     if [ -n "$db_cert_path" ]; then
         # use # as separator instead of slash
@@ -391,30 +387,49 @@ populatePhpEnv() {
         # remove this if not in use
         sed -i -e "/%DB_CERT_PATH%/d" /etc/php84/php-fpm.d/elabpool.conf
     fi
-    if [[ -n $secret_key_file && -r $secret_key_file ]]; then
-        secret_key=$(cat "${secret_key_file}")
-    fi
-    sed -i -e "s/%SECRET_KEY%/${secret_key}/" /etc/php84/php-fpm.d/elabpool.conf
+    
     sed -i -e "s/%MAX_UPLOAD_SIZE%/${max_upload_size}/" /etc/php84/php-fpm.d/elabpool.conf
     sed -i -e "s/%MAX_UPLOAD_TIME%/${max_upload_time}/" /etc/php84/php-fpm.d/elabpool.conf
     # use # as separator instead of slash
     sed -i -e "s#%SITE_URL%#${site_url}#" /etc/php84/php-fpm.d/elabpool.conf
+}
+
+populateSecrets() {
+    if [[ ! -d /run/secrets ]]; then
+        mkdir /run/secrets
+    fi
+
     if [[ -n $aws_ak || -n $aws_ak_file ]]; then
-        if [[ -n aws_ak_file && -r $aws_ak_file ]]; then 
-            aws_ak=$(cat "${aws_ak_file}")
+        if [[ ! -r $aws_ak_file ]]; then 
+            aws_ak_file=/run/secrets/elab_aws_access_key
+            printf "%s" "$aws_ak" > "$aws_ak_file"
         fi
-        sed -i -e "s|%ELAB_AWS_ACCESS_KEY%|${aws_ak}|" /etc/php84/php-fpm.d/elabpool.conf
+        sed -i -e "s|%ELAB_AWS_ACCESS_KEY%|${aws_ak_file}|" /etc/php84/php-fpm.d/elabpool.conf
     else
         sed -i -e "/%ELAB_AWS_ACCESS_KEY%/d" /etc/php84/php-fpm.d/elabpool.conf
-    fi 
+    fi
+    
     if [[ -n $aws_sk || -n $aws_sk_file ]]; then
-        if [[ -n $aws_sk_file && -r $aws_sk_file ]]; then
-            aws_sk=$(cat "${aws_sk_file}")
+        if [[ ! -r $aws_sk_file ]]; then 
+            $aws_sk_file=/run/secrets/elab_aws_secret_key
+            printf "%s" "$aws_sk" > "$aws_sk_file"
         fi
-        sed -i -e "s|%ELAB_AWS_SECRET_KEY%|${aws_sk}|" /etc/php84/php-fpm.d/elabpool.conf
+        sed -i -e "s|%ELAB_AWS_SECRET_KEY%|${aws_sk_file}|" /etc/php84/php-fpm.d/elabpool.conf
     else
         sed -i -e "/%ELAB_AWS_SECRET_KEY%/d" /etc/php84/php-fpm.d/elabpool.conf
     fi
+    
+    if [[ ! -r $secret_key_file ]]; then
+        secret_key_file=/run/secrets/elab_secret_key
+        printf "%s" "$secret_key" > "$secret_key_file"
+    fi
+    sed -i -e "s|%SECRET_KEY%|${secret_key_file}|" /etc/php84/php-fpm.d/elabpool.conf
+
+    if [[ ! -r $db_password_file ]]; then
+        db_password_file="/run/secrets/elab_db_password"
+        printf "%s" "$db_password" > "$db_password_file"
+    fi
+    sed -i -e "s|%DB_PASSWORD%|${db_password_file}|" /etc/php84/php-fpm.d/elabpool.conf
 }
 
 # display a friendly message with running versions
@@ -459,6 +474,7 @@ phpConf
 elabftwConf
 ldapConf
 populatePhpEnv
+populateSecrets
 dbInit
 dbUpdate
 startupMessage


### PR DESCRIPTION
The variables:

- DB_PASSWORD
- SECRET_KEY
- REDIS_PASSWORD
- ELAB_AWS_ACCESS_KEY
- ELAB_AWS_SECRET_KEY

can optionally be provided using a file path in the container by adding the string _FILE to them.
For example: `SECRET_KEY_FILE=/run/secrets/secret_key` and the corresponding specification in the docker compose file.

In case both specifications are present, the `_FILE` variable takes precedence. 

Related:

* https://github.com/elabftw/elabftw/pull/6398
* https://github.com/elabftw/elabftw/discussions/6357


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker secrets support for enhanced security of sensitive credentials, including AWS access keys, database passwords, and encryption keys
  * Implemented file-based environment configuration, allowing credentials to be sourced from secure secret files rather than direct environment variables in containerized deployments
  * Enhanced container initialization with automatic secret management and validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->