### PR TITLE
feat: add MAINTENANCE_MODE support

### DIFF
--- a/src/docker-compose.yml-EXAMPLE
+++ b/src/docker-compose.yml-EXAMPLE
@@ -293,6 +293,10 @@ services:
         # default value: false
         #- DEMO_MODE=false
 
+        # set to true to set the instance in maintenance mode, displaying an informative page, thereby disabling all user interaction
+        # default value: false
+        #- MAINTENANCE_MODE=false
+
         ###########
         # PLUGINS #
         ###########

--- a/src/entrypoint/docker-entrypoint.sh
+++ b/src/entrypoint/docker-entrypoint.sh
@@ -53,6 +53,7 @@ getEnv() {
     silent_init=${SILENT_INIT:-false}
     dev_mode=${DEV_MODE:-false}
     demo_mode=${DEMO_MODE:-false}
+    maintenance_mode=${MAINTENANCE_MODE:-false}
     auto_db_init=${AUTO_DB_INIT:-false}
     auto_db_update=${AUTO_DB_UPDATE:-false}
     aws_ak=${ELAB_AWS_ACCESS_KEY:-}
@@ -129,6 +130,8 @@ nginxConf() {
     if ($disable_https); then
         # activate an HTTP server listening on port 443
         ln -fs /etc/nginx/http.conf /etc/nginx/conf.d/elabftw.conf
+
+    # HTTPS config
     else
         mkdir -p /etc/nginx/certs
         # generate a selfsigned certificate if we don't use Let's Encrypt
@@ -150,6 +153,12 @@ nginxConf() {
     # works also for the ssl config if ssl is enabled
     # here elabftw.conf is a symbolic link to either http.conf or https.conf
     sed -i -e "s/%SERVER_NAME%/${server_name}/" /etc/nginx/conf.d/elabftw.conf
+
+    # for maintenance mode we replace common.conf with maintenance.conf
+    if ($maintenance_mode); then
+        ln -fs /etc/nginx/maintenance.conf /etc/nginx/common.conf
+    fi
+
 
     # set the list of php files that can be processed by php-fpm
     php_files_nginx_allowlist=$(find /elabftw/web -type f -name '*.php' | sed 's:/elabftw/web/::' | tr '\n' '|' | sed 's/|$//')

--- a/src/nginx/maintenance.conf
+++ b/src/nginx/maintenance.conf
@@ -1,0 +1,22 @@
+# maintenance mode config file
+# when MAINTENANCE_MODE=true
+root /elabftw/web/maintenance;
+index index.html;
+
+# Allow only GET requests
+if ($request_method != GET) {
+    return 405;
+}
+
+location = /maintenance.webp {
+    try_files /maintenance.webp =404;
+    add_header Cache-Control "public, max-age=3600";
+}
+
+# Return index.html for all requests
+location / {
+    try_files /index.html =404;
+}
+
+# explicit error page for 405
+error_page 405 /index.html;

--- a/src/nginx/maintenance.conf
+++ b/src/nginx/maintenance.conf
@@ -2,10 +2,15 @@
 # when MAINTENANCE_MODE=true
 root /elabftw/web/maintenance;
 index index.html;
+proxy_temp_path /run/proxy;
 
 # Allow only GET requests
 if ($request_method != GET) {
     return 405;
+}
+
+location = /favicon.ico {
+    try_files /favicon.ico =404;
 }
 
 location = /maintenance.webp {


### PR DESCRIPTION
fix elabftw/elabftw#3962
goes with https://github.com/elabftw/elabftw/pull/6564

use a dedicated nginx included file for this mode



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a maintenance mode toggle (off by default) via environment configuration.
  * When enabled, visitors see a maintenance page; non-GET requests are rejected (405) and key assets are served with caching.
* **Chores**
  * Deployment/startup now respects the maintenance toggle to switch to the maintenance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->